### PR TITLE
Maintenance for modern compiler

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "04:00"
+  open-pull-requests-limit: 10

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install packages
-      run: sudo apt-get install libboost-all-dev ;
+      run: sudo apt-get update ; sudo apt-get install libboost-all-dev ;
     - name: checkout libsdd
       run: git clone -depth 1 https://github.com/ahamez/libsdd.git
     - name: configure

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -13,7 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout repository and submodules
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
     - name: Install packages (with workaround for bad mirror)
       run: sudo gem install apt-spy2 ; sudo apt-spy2 check ; sudo apt-spy2 fix --commit ; sudo apt-get update ; sudo apt-get install libboost-all-dev ;
     - name: checkout libsdd

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,7 +22,7 @@ jobs:
     - name: checkout libsdd
       run: git clone --depth 1 https://github.com/ahamez/libsdd.git
     - name: configure
-      run: mkdir build ; cd build ; cmake .. -DLIBSDD_PATH=$PWD/../libsdd -DSTATIC_BOOST=ON ; make -j 4; cd ..
+      run: mkdir build ; cd build ; cmake .. -DLIBSDD_PATH=$PWD/../libsdd -DSTATIC_BOOST=ON ; make -j 4; sed -i 's/-Wl,-Bdynamic//g'  pnmc/CMakeFiles/pnmc.dir/link.txt ; make pnmc ; cd ..
     - name: strip binaries
       run: strip -s build/pnmc/pnmc ; mkdir website ; cp build/pnmc/pnmc website/pnmc 
     - name: checkout Caesar.SDD

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -25,10 +25,6 @@ jobs:
       run: mkdir build ; cd build ; cmake .. -DLIBSDD_PATH=$PWD/../libsdd -DSTATIC_BOOST=ON ; make -j 4; sed -i 's/-Wl,-Bdynamic//g'  pnmc/CMakeFiles/pnmc.dir/link.txt ; make pnmc ; cd ..
     - name: strip binaries
       run: strip -s build/pnmc/pnmc ; mkdir website ; cp build/pnmc/pnmc website/pnmc 
-    - name: checkout Caesar.SDD
-      run: git clone --depth 1 https://github.com/ahamez/caesar.sdd
-    - name: build Caesar.SDD
-      run: cd caesar.sdd ; mkdir build ; cd build ; cmake .. -DLIBSDD_PATH=$PWD/../../libsdd -DSTATIC_BOOST=ON ; make caesar.sdd ; cat src/CMakeFiles/caesar.sdd.dir/link.txt ; sed -i 's/-Wl,-Bdynamic/-static-libgcc -static-libstdc++ -static/g' src/CMakeFiles/caesar.sdd.dir/link.txt  ; make caesar.sdd VERBOSE=1 ; strip -s src/caesar.sdd ; cp src/caesar.sdd ../../website/ ; cd ../.. ;
     - name: Deploy to GitHub Pages
       uses: JamesIves/github-pages-deploy-action@v4.4.1
       with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,13 +17,13 @@ jobs:
     - name: Install packages (with workaround for bad mirror)
       run: sudo gem install apt-spy2 ; sudo apt-spy2 check ; sudo apt-spy2 fix --commit ; sudo apt-get update ; sudo apt-get install libboost-all-dev ;
     - name: checkout libsdd
-      run: git clone -depth 1 https://github.com/ahamez/libsdd.git
+      run: git clone --depth 1 https://github.com/ahamez/libsdd.git
     - name: configure
       run: mkdir build ; cd build ; cmake .. -DLIBSDD_PATH=$PWD/../libsdd -DSTATIC_BOOST=ON ; make -j 4; cd ..
     - name: strip binaries
       run: strip -s build/pnmc/pnmc ; mkdir website ; cp build/pnmc/pnmc website/pnmc 
     - name: checkout Caesar.SDD
-      run: git clone -depth 1 https://github.com/ahamez/caesar.sdd
+      run: git clone --depth 1 https://github.com/ahamez/caesar.sdd
     - name: build Caesar.SDD
       run: cd caesar.sdd ; mkdir build ; cd build ; cmake .. -DLIBSDD_PATH=$PWD/../../libsdd -DSTATIC_BOOST=ON ; make caesar.sdd ; strip -s src/caesar.sdd ; cp src/caesar.sdd ../../website/ ; cd ../.. ;
     - name: Deploy to GitHub Pages

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -28,7 +28,7 @@ jobs:
     - name: checkout Caesar.SDD
       run: git clone --depth 1 https://github.com/ahamez/caesar.sdd
     - name: build Caesar.SDD
-      run: cd caesar.sdd ; mkdir build ; cd build ; cmake .. -DLIBSDD_PATH=$PWD/../../libsdd -DSTATIC_BOOST=ON ; make caesar.sdd ; sed -i 's/-Wl,-Bdynamic/-static-libgcc -static-libstdc++ -static/g' src/CMakeFiles/caesar.sdd.dir/link.txt  ; make caesar.sdd ; strip -s src/caesar.sdd ; cp src/caesar.sdd ../../website/ ; cd ../.. ;
+      run: cd caesar.sdd ; mkdir build ; cd build ; cmake .. -DLIBSDD_PATH=$PWD/../../libsdd -DSTATIC_BOOST=ON ; make caesar.sdd ; cat src/CMakeFiles/caesar.sdd.dir/link.txt ; sed -i 's/-Wl,-Bdynamic/-static-libgcc -static-libstdc++ -static/g' src/CMakeFiles/caesar.sdd.dir/link.txt  ; make caesar.sdd VERBOSE=1 ; strip -s src/caesar.sdd ; cp src/caesar.sdd ../../website/ ; cd ../.. ;
     - name: Deploy to GitHub Pages
       uses: JamesIves/github-pages-deploy-action@v4.4.1
       with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,7 +22,10 @@ jobs:
       run: mkdir build ; cd build ; cmake .. -DLIBSDD_PATH=$PWD/../libsdd -DSTATIC_BOOST=ON ; make -j 4; cd ..
     - name: strip binaries
       run: strip -s build/pnmc/pnmc ; mkdir website ; cp build/pnmc/pnmc website/pnmc 
-    
+    - name: checkout Caesar.SDD
+      run: git clone -depth 1 https://github.com/ahamez/caesar.sdd
+    - name: build Caesar.SDD
+      run: cd caesar.sdd ; mkdir build ; cd build ; cmake .. -DLIBSDD_PATH=$PWD/../../libsdd -DSTATIC_BOOST=ON ; make caesar.sdd ; strip -s src/caesar.sdd ; cp src/caesar.sdd ../../website/ ; cd ../.. ;
     - name: Deploy to GitHub Pages
       uses: JamesIves/github-pages-deploy-action@v4.4.1
       with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,32 @@
+name: Linux Build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  repository_dispatch:
+    types: [Linux]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install packages
+      run: sudo apt-get install libboost-all-dev ;
+    - name: checkout libsdd
+      run: git clone -depth 1 https://github.com/ahamez/libsdd.git
+    - name: configure
+      run: mkdir build ; cd build ; cmake .. -DLIBSDD_PATH=$PWD/../libsdd -DSTATIC_BOOST=ON ; make -j 4; cd ..
+    - name: strip binaries
+      run: strip -s build/pnmc/pnmc ; mkdir website ; cp build/pnmc/pnmc website/pnmc 
+    
+    - name: Deploy to GitHub Pages
+      uses: JamesIves/github-pages-deploy-action@v4.4.1
+      with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: website/ # The folder the action should deploy.
+          clean: true # Automatically remove deleted files from the deploy branch 
+          single-commit: true

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -14,8 +14,8 @@ jobs:
     
     steps:
     - uses: actions/checkout@v3
-    - name: Install packages
-      run: sudo apt-get update ; sudo apt-get install libboost-all-dev ;
+    - name: Install packages (with workaround for bad mirror)
+      run: sudo gem install apt-spy2 ; sudo apt-spy2 check ; sudo apt-spy2 fix --commit ; sudo apt-get update ; sudo apt-get install libboost-all-dev ;
     - name: checkout libsdd
       run: git clone -depth 1 https://github.com/ahamez/libsdd.git
     - name: configure

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -28,7 +28,7 @@ jobs:
     - name: checkout Caesar.SDD
       run: git clone --depth 1 https://github.com/ahamez/caesar.sdd
     - name: build Caesar.SDD
-      run: cd caesar.sdd ; mkdir build ; cd build ; cmake .. -DLIBSDD_PATH=$PWD/../../libsdd -DSTATIC_BOOST=ON ; make caesar.sdd ; strip -s src/caesar.sdd ; cp src/caesar.sdd ../../website/ ; cd ../.. ;
+      run: cd caesar.sdd ; mkdir build ; cd build ; cmake .. -DLIBSDD_PATH=$PWD/../../libsdd -DSTATIC_BOOST=ON ; make caesar.sdd ; sed -i 's/-Wl,-Bdynamic/-static-libgcc -static-libstdc++ -static/g' src/CMakeFiles/caesar.sdd.dir/link.txt  ; make caesar.sdd ; strip -s src/caesar.sdd ; cp src/caesar.sdd ../../website/ ; cd ../.. ;
     - name: Deploy to GitHub Pages
       uses: JamesIves/github-pages-deploy-action@v4.4.1
       with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ option (STATIC_BOOST "Force usage of static Boost libraries OFF")
 
 if (STATIC_BOOST)
   set(Boost_USE_STATIC_LIBS ON)
+  set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++ -static")
 endif ()
 find_package(Boost 1.58.0 REQUIRED COMPONENTS program_options coroutine context system thread filesystem)
 
@@ -58,10 +59,8 @@ find_package (Threads)
 
 set(CMAKE_CXX_FLAGS "-Wall -Wextra -std=c++14 ${CMAKE_CXX_FLAGS}")
 
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-  if (CMAKE_BUILD_TYPE STREQUAL "Release")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -flto")
-  endif ()
+if (CMAKE_BUILD_TYPE STREQUAL "Release")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -flto")
 endif ()
 
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,6 @@ option (STATIC_BOOST "Force usage of static Boost libraries OFF")
 
 if (STATIC_BOOST)
   set(Boost_USE_STATIC_LIBS ON)
-  set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++ -static")
 endif ()
 find_package(Boost 1.58.0 REQUIRED COMPONENTS program_options coroutine context system thread filesystem)
 
@@ -68,6 +67,11 @@ if (COVERAGE AND CMAKE_BUILD_TYPE MATCHES Debug)
   include(CodeCoverage)
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} --coverage")
 endif()
+
+if (STATIC_BOOST)
+  set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++ -static")
+endif ()
+
 
 #--------------------------------------------------------------------------------------------------#
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,6 @@ to optimize the generation of state spaces.
 
 - Instructions to compile and install pnmc are given in the INSTALL file.
 
-- We also distribute the tool as a static binary for Linux x64 : [pnmc](https://github.com/yanntm/pnmc/raw/gh-pages/pnmc) [caesar.sdd](https://github.com/yanntm/pnmc/raw/gh-pages/caesar.sdd). These binaries are built from latest versions of source using GitHub actions (see "actions" tab at top of this page)
+- We also distribute the tool as a static binary for Linux x64 : [pnmc](https://github.com/yanntm/pnmc/raw/gh-pages/pnmc) These binaries are built from latest versions of source using GitHub actions (see "actions" tab at top of this page)
 
  

--- a/README.md
+++ b/README.md
@@ -16,3 +16,7 @@ to optimize the generation of state spaces.
 ## Installation
 
 - Instructions to compile and install pnmc are given in the INSTALL file.
+
+- We also distribute the tool as a static binary for Linux x64 : [pnmc](https://github.com/yanntm/pnmc/raw/gh-pages/pnmc) [caesar.sdd](https://github.com/yanntm/pnmc/raw/gh-pages/caesar.sdd). These binaries are built from latest versions of source using GitHub actions (see "actions" tab at top of this page)
+
+ 

--- a/pnmc/mc/classic/advance.hh
+++ b/pnmc/mc/classic/advance.hh
@@ -44,7 +44,7 @@ struct advance
     {
       builder.insert(builder.end(), pn::sharp);
     }
-    return std::move(builder);
+    return builder;
   }
 
   bool

--- a/pnmc/mc/classic/advance_capped.hh
+++ b/pnmc/mc/classic/advance_capped.hh
@@ -41,7 +41,7 @@ struct advance_capped
     {
       builder.insert(builder.end(), pn::sharp);
     }
-    return std::move(builder);
+    return builder;
   }
 
   bool

--- a/pnmc/mc/classic/bounded_post.hh
+++ b/pnmc/mc/classic/bounded_post.hh
@@ -40,7 +40,7 @@ struct bounded_post
       }
       builder.insert(builder.end(), v + valuation);
     }
-    return std::move(builder);
+    return builder;
   }
 
   friend

--- a/pnmc/mc/classic/enabled.hh
+++ b/pnmc/mc/classic/enabled.hh
@@ -36,7 +36,7 @@ struct enabled
         builder.insert(builder.end(), v);
       }
     }
-    return std::move(builder);
+    return builder;
   }
 
   bool

--- a/pnmc/mc/classic/enabled_inhibitor.hh
+++ b/pnmc/mc/classic/enabled_inhibitor.hh
@@ -36,7 +36,7 @@ struct enabled_inhibitor
         builder.insert(builder.end(), v);
       }
     }
-    return std::move(builder);
+    return builder;
   }
 
   bool

--- a/pnmc/mc/classic/filter_ge.hh
+++ b/pnmc/mc/classic/filter_ge.hh
@@ -31,7 +31,7 @@ struct filter_ge
     builder.reserve(val.size());
     // Only keep values that are greater or equal than the requested valuation.
     std::copy(val.lower_bound(value), val.cend(), std::inserter(builder, builder.end()));
-    return std::move(builder);
+    return builder;
   }
 
   bool

--- a/pnmc/mc/classic/filter_lt.hh
+++ b/pnmc/mc/classic/filter_lt.hh
@@ -31,7 +31,7 @@ struct filter_lt
     builder.reserve(val.size());
     // Only keep values that are less than the requested valuation.
     std::copy(val.cbegin(), val.lower_bound(value), std::inserter(builder, builder.end()));
-    return std::move(builder);
+    return builder;
   }
 
   bool

--- a/pnmc/mc/classic/path_to.cc
+++ b/pnmc/mc/classic/path_to.cc
@@ -288,7 +288,7 @@ shortest_path( const order& o, const SDD& initial, const SDD& targets, const pn:
     const auto next_states = *std::prev(rcit);
     const auto a_state = one_state_of(next_states);
     
-    for (const auto transition : transitions)
+    for (const auto & transition : transitions)
     {
       const auto res = visit( visitor{transition}
                             , *rcit            // current states to filter

--- a/pnmc/mc/classic/post.hh
+++ b/pnmc/mc/classic/post.hh
@@ -31,7 +31,7 @@ struct post
     builder.reserve(val.size());
     std::transform( val.cbegin(), val.cend(), std::inserter(builder, builder.end())
                   , [this](unsigned int v){return v + valuation;});
-    return std::move(builder);
+    return builder;
   }
 
   bool

--- a/pnmc/mc/classic/pre.hh
+++ b/pnmc/mc/classic/pre.hh
@@ -32,7 +32,7 @@ struct pre
     // Start from first entry in val that is greater or equal than valuation.
     std::transform( val.lower_bound(valuation), val.cend(), std::inserter(builder, builder.end())
                   , [this](unsigned int v){return v - valuation;});
-    return std::move(builder);
+    return builder;
   }
 
   bool

--- a/pnmc/mc/classic/pre_clock.hh
+++ b/pnmc/mc/classic/pre_clock.hh
@@ -38,7 +38,7 @@ struct pre_clock
         builder.insert(builder.end(), *cit);
       }
     }
-    return std::move(builder);
+    return builder;
   }
 
   bool

--- a/pnmc/mc/shared/results.hh
+++ b/pnmc/mc/shared/results.hh
@@ -46,7 +46,9 @@ struct results
   {
     if (r.states)
     {
-      os << r.states->size().template convert_to<long double>() << " state(s)\n";
+//      os << r.states->size().template convert_to<long double>() << " state(s)\n";
+//    MCC now requires exact state count
+      os << r.states->size() << " state(s)\n";
     }
     if (r.max_token_markings)
     {
@@ -129,6 +131,7 @@ struct results
       for (const auto& id_status : *r.reachability)
       {
         os << "  " << id_status.first << " : " << std::boolalpha << id_status.second << '\n';
+        os << "FORMULA " << id_status.first << " " << (id_status.second?"TRUE":"FALSE") << " TECHNIQUES DECISION_DIAGRAMS" << std::endl;
       }
     }
 

--- a/support/pn/module.hh
+++ b/support/pn/module.hh
@@ -9,6 +9,7 @@
 #include <functional> // reference_wrapper
 #include <string>
 #include <vector>
+#include <memory>
 
 #include <boost/variant.hpp>
 


### PR DESCRIPTION
Salut Alex,

on a un nouveau mode de soumission au MCC qui permet d'avoir des outils de "référence" pour se comparer, sans que ces outils soient directement en compétition. En particulier ça permet de soumettre d'autres outils (i.e. pas les siens propre).

Bref, j'essaie de resusciter pnmc; je me base sur ta VM de 2016.

Je pense l'outil peut faire StateSpace (sauf le compte de transitions) et aussi QuasiLive (via l'option de calculer les dead transitions).

On pourrait aussi faire OneSafe, i.e. vrai ssi toutes les places sont bornées à 1, via "max token in place" qui est déjà calculé.

On a aussi Deadlock je crois.

Par contre j'ai essayé de décommenter/activer du code pour ReachabilityFireability, mais ça ne fait pas ce qu'il faut, il n'y a pas vraiment de moteur pour extraire le sous DD qui satisfait un prédicat arbitraire sur les variables genre "x+y < z+3" (je crois du moins).

Mais du coup on est limité à une composition de filtres qui ne voient qu'une variable j'ai l'impression, ce serait suffisant normalement pour faire Fireability, mais pas Cardinality. Comme c'est compliqué, je vais laisser tomber cette partie Reachability pour l'instant.

Dans ce PR il y a  
* au passage de la compilation j'ai patché deux trois warnings des compilos modernes, 
* commencé à patcher pour parser directement la syntaxe du MCC. Mais pour l'instant j'arrête cette direction.
Donc rien de vraiment sémantique.

L'adapter que je développe est basé sur le contenu de ta VM de 2016, ça vit ici : 
https://github.com/yanntm/MCC-drivers/tree/master/pnmc

Je pense ajouter un déplieur devant pour les colorés.

a+
yann
